### PR TITLE
chore: remove browserslist update from typescript-validation build step

### DIFF
--- a/.github/workflows/typescript-validation.yaml
+++ b/.github/workflows/typescript-validation.yaml
@@ -80,7 +80,7 @@ jobs:
           npm_token: $NPM_TOKEN
 
       - name: 🔧 Building Environment
-        run: npm run build --if-present && npx browserslist@latest --update-db
+        run: npm run build --if-present
 
       - name: 🔧 Run Tests
         id: run_test


### PR DESCRIPTION
## Summary
- Removes `npx browserslist@latest --update-db` from the Building Environment step in `typescript-validation.yaml`

## Test plan
- [x] Verify the TypeScript validation workflow still runs successfully without the browserslist update step

🤖 Generated with [Claude Code](https://claude.com/claude-code)