### PR TITLE
chore: remove browserslist update from npm-publication and sonar-analysis

### DIFF
--- a/.github/workflows/npm-publication.yaml
+++ b/.github/workflows/npm-publication.yaml
@@ -89,7 +89,7 @@ jobs:
           npm_token: $NPM_TOKEN
 
       - name: 🏗️ Building Environment
-        run: npm run build --if-present && npx --yes browserslist@latest --update-db
+        run: npm run build --if-present
 
       - name: 🚀 Update version
         run: npm --no-git-tag-version version ${{ inputs.release_version_name }}

--- a/.github/workflows/sonar-analysis.yaml
+++ b/.github/workflows/sonar-analysis.yaml
@@ -50,7 +50,7 @@ jobs:
           npm_token: $NPM_TOKEN
 
       - name: 🔧 Building Environment
-        run: npm run build --if-present && npx browserslist@latest --update-db
+        run: npm run build --if-present
 
       - name: 🔧 Run Tests
         id: run_test

--- a/.github/workflows/typescript-validation.yaml
+++ b/.github/workflows/typescript-validation.yaml
@@ -80,7 +80,7 @@ jobs:
           npm_token: $NPM_TOKEN
 
       - name: 🔧 Building Environment
-        run: npm run build --if-present && npx browserslist@latest --update-db
+        run: npm run build --if-present
 
       - name: 🔧 Run Tests
         id: run_test


### PR DESCRIPTION
## Summary
- Removes `npx browserslist@latest --update-db` from the Building Environment step in `npm-publication.yaml`
- Removes `npx browserslist@latest --update-db` from the Building Environment step in `sonar-analysis.yaml`

Follows up on #139 which applied the same change to `typescript-validation.yaml`.

## Test plan
- [ ] Verify npm-publication workflow still runs successfully without the browserslist update step
- [ ] Verify sonar-analysis workflow still runs successfully without the browserslist update step

🤖 Generated with [Claude Code](https://claude.com/claude-code)